### PR TITLE
before_action-add

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-  # before_action :authenticate_user!
+  before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :basic_auth, if: :production?
 


### PR DESCRIPTION
#what
before_action :authenticate_user!のコメントアウトを解除

#why
ログインしていない場合は、ログイン画面に遷移させるため