### PR TITLE
delete

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-  before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :basic_auth, if: :production?
 


### PR DESCRIPTION
#what
user_authenticateを削除する

#why
Basic認証の設定を反映させるため